### PR TITLE
Add a root folder for the product archives

### DIFF
--- a/org.eclipselabs.equinox.p2.admin.product/pom.xml
+++ b/org.eclipselabs.equinox.p2.admin.product/pom.xml
@@ -29,6 +29,14 @@
 	      <groupId>org.eclipse.tycho</groupId>
 	      <artifactId>tycho-p2-director-plugin</artifactId>
 	      <version>${tycho-version}</version>
+	      <configuration>
+		<products>
+		  <product>
+		    <id>org.eclipse.equinox.p2.admin.rcp.product</id>
+		    <rootFolder>p2-admin</rootFolder>
+		  </product>
+		</products>
+	      </configuration>
 	      <executions>
 	        <execution>
 	          <id>materialize-products</id>


### PR DESCRIPTION
Without this, the zip archives produced have a flat structure, and unzipping them drops all the "p2", "configuration" etc. folders and files in the current folder.
